### PR TITLE
Fully drop support for Puppet 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ matrix:
     - rvm: 2.1.6
       sudo: required
       services: docker
-      env: BEAKER_set="centos-6-x64-docker" PUPPET_INSTALL_VERSION=3.8.6 PUPPET_INSTALL_TYPE=foss
+      env: BEAKER_set="centos-6-x64-docker"
       bundler_args:
       script: sudo service docker restart ; sleep 10 ; bundle exec rake beaker
     - rvm: 2.1.6
       sudo: required
       services: docker
-      env: BEAKER_set="centos-7-x64-docker" PUPPET_INSTALL_VERSION=3.8.6 PUPPET_INSTALL_TYPE=foss
+      env: BEAKER_set="centos-7-x64-docker"
       bundler_args:
       script: sudo service docker restart ; sleep 10 ; bundle exec rake beaker
 notifications:

--- a/metadata.json
+++ b/metadata.json
@@ -31,5 +31,8 @@
     { "name": "puppetlabs/concat", "version_requirement": ">= 2.2.1 <3.0.0"},
     { "name": "stahnma/epel", "version_requirement": ">=0.0.6 <2.0.0" },
     { "name": "puppet/autofs", "version_requirement": ">=3.1.0 <4.0.0"}
+  ],
+  "requirements": [
+    {"name": "puppet", "version_requirement": ">= 4.7.0 < 6.0.0" }
   ]
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,31 +13,10 @@ RSpec.configure do |c|
   # Readable test descriptions
   c.formatter = :documentation
 
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
   c.before :suite do
     hosts.each do |h|
       scp_to h, File.join(proj_root, 'spec/fixtures/make-dummy-cert'), '/tmp/make-dummy-cert'
       on h, '/tmp/make-dummy-cert /tmp/host /tmp/bestman /tmp/rsv /tmp/http'
-
-      install_puppet_module_via_pmt_on(h, :module_name => 'puppetlabs-inifile')
-      puppet_pp = <<-EOF
-      ini_setting { 'puppet.conf/main/show_diff':
-        ensure  => 'present',
-        section => 'main',
-        path    => '/etc/puppet/puppet.conf',
-        setting => 'show_diff',
-        value   => 'true',
-      }
-      ini_setting { 'puppet.conf/main/parser':
-        ensure  => 'present',
-        section => 'main',
-        path    => '/etc/puppet/puppet.conf',
-        setting => 'parser',
-        value   => 'future',
-      }
-      EOF
-      apply_manifest_on(h, puppet_pp, :catch_failures => true)
     end
   end
 end


### PR DESCRIPTION
Puppet 3 with future parser should still work but no longer testing that works.