### PR TITLE
Remove old autofs parameter mapfile_manage

### DIFF
--- a/manifests/cvmfs/config.pp
+++ b/manifests/cvmfs/config.pp
@@ -17,10 +17,9 @@ class osg::cvmfs::config {
   }
 
   autofs::mount { 'cvmfs':
-    mount          => '/cvmfs',
-    mapfile        => '/etc/auto.cvmfs',
-    order          => 50,
-    mapfile_manage => false,
+    mount   => '/cvmfs',
+    mapfile => '/etc/auto.cvmfs',
+    order   => 50,
   }
 
   file { '/etc/cvmfs/default.local':

--- a/spec/classes/osg_cvmfs_spec.rb
+++ b/spec/classes/osg_cvmfs_spec.rb
@@ -149,10 +149,9 @@ describe 'osg::cvmfs' do
 
         it do
           should contain_autofs__mount('cvmfs').with({
-            :mount          => '/cvmfs',
-            :mapfile        => '/etc/auto.cvmfs',
-            :order          => '50',
-            :mapfile_manage => 'false',
+            :mount   => '/cvmfs',
+            :mapfile => '/etc/auto.cvmfs',
+            :order   => '50',
           })
         end
 


### PR DESCRIPTION
Saw your closed issue on puppet-autofs, but looks like your module was never updated.  These minor edits were required for Puppet5.  Then worked great, tested on RHEL7.  