### PR TITLE
Allow repos to be disabled

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,5 @@
 # Class: osg: See README.md for documentation.
 class osg (
-  Boolean $enable_osg = true,
   Enum['3.4'] $osg_release = '3.4',
   Optional[String] $repo_baseurl_bit = 'https://repo.opensciencegrid.org',
   Optional[String] $repo_development_baseurl_bit = undef,
@@ -8,6 +7,8 @@ class osg (
   Optional[String] $repo_upcoming_baseurl_bit = undef,
   Boolean $repo_use_mirrors = true,
   Optional[String] $repo_gpgkey = undef,
+  Boolean $enable_osg = true,
+  Boolean $enable_osg_empty = true,
   Boolean $enable_osg_contrib = false,
   Boolean $manage_epel = true,
   Enum['lcmaps_voms'] $auth_type = 'lcmaps_voms',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
 # Class: osg: See README.md for documentation.
 class osg (
+  Boolean $enable_osg = true,
   Enum['3.4'] $osg_release = '3.4',
   Optional[String] $repo_baseurl_bit = 'https://repo.opensciencegrid.org',
   Optional[String] $repo_development_baseurl_bit = undef,

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -64,7 +64,7 @@ class osg::repos {
     baseurl    => $baseurls['osg'],
     mirrorlist => $mirrorlists['osg'],
     descr      => "OSG Software for Enterprise Linux ${::operatingsystemmajrelease} - ${::architecture}",
-    enabled    => '1',
+    enabled    => bool2num($osg::enable_osg),
   }
 
   yumrepo { 'osg-empty':

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -71,7 +71,7 @@ class osg::repos {
     baseurl     => $baseurls['osg-empty'],
     mirrorlist  => $mirrorlists['osg-empty'],
     descr       => "OSG Software for Enterprise Linux ${::operatingsystemmajrelease} - Empty Packages - ${::architecture}",
-    enabled     => '1',
+    enabled     => bool2num($osg::enable_osg_empty),
     includepkgs => 'empty-ca-certs empty-slurm empty-torque',
   }
 


### PR DESCRIPTION
We sync all external repos to Foreman so that we can rebuild hosts to snapshots of older rpm sets.  This was simplest, least disruptive set of changes I could come up with to disable off-site OSG repositories.  This has a very similar usage to "osg::manage_epel: false".